### PR TITLE
Add user greeting and restyle checker

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,3 +1,10 @@
+<?php
+session_start();
+if(!isset($_SESSION["user_id"])){
+    header("Location: login.php");
+    exit;
+}
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -6,12 +13,12 @@
   <title>Live Proxy Checker™</title>
   <style>
     :root {
-      --neon1: #ff0080;
-      --neon2: #00ffee;
-      --neon3: #ffdd00;
-      --bg: #0d0d0d;
-      --text: #e0e0e0;
-      --panel: #111;
+      --neon1: #00f6ff;
+      --neon2: #00f6ff;
+      --neon3: #00f6ff;
+      --bg: #151515;
+      --text: #fff;
+      --panel: #222;
       --ok-bg: rgba(0,255,0,0.1);
       --fail-bg: rgba(255,0,0,0.1);
       --ok-border: #00ff00;
@@ -22,39 +29,36 @@
       margin: 0;
       padding: 0;
     }
-    body {
-      display: flex;
-      justify-content: center;
-      align-items: flex-start;
-      min-height: 100vh;
-      padding: 2rem;
-      background: linear-gradient(45deg, var(--neon1), var(--neon2), var(--neon3), var(--neon1));
-      background-size: 400% 400%;
-      animation: bgAnim 15s ease infinite;
-      font-family: 'Segoe UI', sans-serif;
-      color: var(--text);
-    }
-    @keyframes bgAnim {
-      0% { background-position: 0% 50%; }
-      50% { background-position: 100% 50%; }
-      100% { background-position: 0% 50%; }
-    }
+      body {
+        margin: 0;
+        font-family: 'Segoe UI', sans-serif;
+        background: linear-gradient(to bottom right, #0f0f0f, #1a1a1a);
+        color: var(--text);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        min-height: 100vh;
+        padding: 2rem;
+      }
     .container {
-      width: 100%;
+      width: 90%;
       max-width: 800px;
       background: var(--bg);
-      border-radius: 16px;
-      box-shadow: 0 0 20px rgba(0,0,0,0.8), 0 0 40px var(--neon1);
-      padding: 2rem;
+      border-radius: 12px;
+      box-shadow: 0 0 25px rgba(0,255,255,0.2);
+      padding: 40px;
       position: relative;
       overflow: hidden;
+      text-align: center;
     }
     h1 {
       text-align: center;
       font-size: 1.8rem;
-      background: conic-gradient(from 90deg, var(--neon1), var(--neon2), var(--neon3));
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
+      margin-bottom: 1rem;
+    }
+    .welcome {
+      font-size: 1rem;
+      color: var(--neon3);
       margin-bottom: 1rem;
     }
     .stats {
@@ -75,9 +79,7 @@
       font-size: 1.2rem;
       font-weight: bold;
       margin: 0.2rem 0;
-      background: linear-gradient(90deg, var(--neon1), var(--neon2));
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
+      color: var(--neon1);
     }
     .stat-label { font-size: 0.7rem; color: #aaa; }
     textarea {
@@ -98,14 +100,21 @@
       margin-bottom: 0.8rem;
       padding: 0.6rem;
       font-size: 0.95rem;
-      border: 2px solid var(--neon1);
-      background: var(--panel);
+      border-radius: 6px;
+    }
+    .controls select {
+      background: #222;
+      border: none;
       color: var(--text);
-      border-radius: 50px;
+    }
+    .controls button {
+      background: var(--neon1);
+      border: none;
+      color: #000;
+      font-weight: bold;
       cursor: pointer;
-      box-shadow: 0 0 8px var(--neon1);
-      transition: all 0.2s;
-      text-align: center;
+      transition: 0.3s ease;
+      box-shadow: 0 0 6px var(--neon1);
     }
     button:disabled {
       opacity: 0.4;
@@ -113,8 +122,7 @@
       box-shadow: none;
     }
     button:not(:disabled):hover {
-      transform: translateY(-1px);
-      box-shadow: 0 0 16px var(--neon2), 0 0 32px var(--neon3);
+      background: #00d1ff;
     }
     .progress-container {
       margin-bottom: 1rem;
@@ -145,20 +153,18 @@
     .pill {
       padding: 0.5rem 1rem;
       border-radius: 999px;
-      background: rgba(255,255,255,0.05);
-      border: 2px solid var(--neon2);
-      color: var(--neon2);
+      background: #222;
+      color: var(--text);
       font-size: 0.9rem;
       font-weight: bold;
       cursor: pointer;
-      box-shadow: 0 0 6px var(--neon2);
-      transition: all 0.2s;
+      box-shadow: 0 0 6px var(--neon1);
+      transition: 0.3s;
       user-select: none;
     }
     .pill.active {
-      background: var(--neon2);
-      color: var(--bg);
-      box-shadow: 0 0 12px var(--neon1), 0 0 24px var(--neon3);
+      background: var(--neon1);
+      color: #000;
     }
     .pill .count { margin-left: 0.4rem; font-size: 1rem; }
     .results {
@@ -216,6 +222,7 @@
   <canvas id="confetti"></canvas>
   <div class="container">
     <h1>Live Proxy Checker™</h1>
+    <div class="welcome">Welcome, <?php echo htmlspecialchars($_SESSION['user_id']); ?></div>
     <div class="stats">
       <div class="stat"><div class="stat-icon">📋</div><div class="stat-value" id="total">0</div><div class="stat-label">Total</div></div>
       <div class="stat"><div class="stat-icon">✔️</div><div class="stat-value" id="checked">0</div><div class="stat-label">Checked</div></div>


### PR DESCRIPTION
## Summary
- show logged-in user name on checker page
- style stats, selectors, and result bubbles to match login page

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc55a47888327a42d3ccc009690e7